### PR TITLE
TableView not taking in account absolute position of TextField

### DIFF
--- a/src/TRAutocompleteView.m
+++ b/src/TRAutocompleteView.m
@@ -133,7 +133,9 @@
         kbHeight = kbSize.width;
     }
 
-    CGFloat calculatedY = _queryTextField.frame.origin.y + _queryTextField.frame.size.height + self.topMargin;
+    CGPoint textPosition = [_queryTextField convertPoint:_queryTextField.bounds.origin toView:nil]; //Taking in account Y position of queryTextField relatively to it's Window
+    
+    CGFloat calculatedY = textPosition.y + _queryTextField.frame.size.height + self.topMargin;
     CGFloat calculatedHeight = contextViewHeight - calculatedY - kbHeight;
 
     calculatedHeight += _contextController.tabBarController.tabBar.frame.size.height; //keyboard is shown over it, need to compensate


### PR DESCRIPTION
In some cases position of UIAutocompleteView was calculated incorrectly: in case when UITextField was located inside another View (so, not directly in view of ViewController).

In my projects I'm using UITextField as a header view of UITableView, so it's located like this:

UIView -> UITableView -> UIView -> UITextField
