### PR TITLE
Update AFNetworking to 1.3

### DIFF
--- a/TRAutocompleteView.podspec
+++ b/TRAutocompleteView.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.frameworks = 'CoreLocation'
-  s.dependency 'AFNetworking', '~> 1.1.0'
+  s.dependency 'AFNetworking', '~> 1.3.0'
 end


### PR DESCRIPTION
Update podspec to use AFNetworking 1.3 so iTRAutocompleteView can be used with other projects that require a newer version of AFNetworking.
