### PR TITLE
Refresh the tableView only if the textField is still the first responder

### DIFF
--- a/src/TRAutocompleteView.m
+++ b/src/TRAutocompleteView.m
@@ -164,12 +164,12 @@
                                                                     < _itemsSource.minimumCharactersToTrigger)
                                                                 {
                                                                     self.suggestions = nil;
-                                                                    [_table reloadData];
+                                                                    [self refreshTable];
                                                                 }
                                                                 else
                                                                 {
                                                                     self.suggestions = suggestions;
-                                                                    [_table reloadData];
+                                                                    [self refreshTable];
 
                                                                     if (self.suggestions.count > 0 && !_visible)
                                                                     {
@@ -182,7 +182,7 @@
     else
     {
         self.suggestions = nil;
-        [_table reloadData];
+        [self refreshTable];
     }
 }
 
@@ -224,6 +224,12 @@
 
     if (self.didAutocompleteWith)
         self.didAutocompleteWith(self.selectedSuggestion);
+}
+
+- (void)refreshTable {
+    if (_queryTextField.isFirstResponder) {
+        [_table reloadData];
+    }
 }
 
 - (void)dealloc


### PR DESCRIPTION
When the network connection is slow and the user fills in the textField without any help from the auto complete, TRAutocompleteView adds a tableView to the bottom of the textField even though the textField is no longer the first responder.
