### PR TITLE
Hide autocomplete view when no suggestions exist

### DIFF
--- a/src/TRAutocompleteView.m
+++ b/src/TRAutocompleteView.m
@@ -146,6 +146,11 @@
                             _queryTextField.frame.size.width,
                             calculatedHeight);
     _table.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
+    
+    if (self.suggestions == nil || self.suggestions.count == 0) {
+        [self removeFromSuperview];
+        _visible = NO;
+    }
 }
 
 - (void)keyboardWillHide:(NSNotification *)notification
@@ -184,6 +189,11 @@
     {
         self.suggestions = nil;
         [self refreshTable];
+    }
+    
+    if (self.suggestions == nil || self.suggestions.count == 0) {
+        [self removeFromSuperview];
+        _visible = NO;
     }
 }
 


### PR DESCRIPTION
The autocomplete view was displaying an empty table even before anything was typed into the text field and also when no suggestions were returned. With these changes, the view is now automatically hidden if there are no suggestions.