### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ TRGoogleMapsAutocompleteItemsSource uses new Places API for autocompletion: http
 **P.S Common mistake: DON NOT USE Google Maps API v3 key, 
 you need Places API KEY instead, otherwise all requests will just fail with REQUEST_DENIED status code**
 
-Cocoapods
+CocoaPods
 ------------------------
 pod 'TRAutocompleteView',       '~> 1.1'
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
